### PR TITLE
Update fly commands of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This concourse pipeline is used for building and deploying nine H801 controllers
 Clone this pipeline and configure vars.yaml (see template)
 
 ## Deploy pipeline
-Download fly for concourse and login with credentials
-- fly -t [concourse-server] login
-- fly -t [concourse-server] set-pipeline -c pipeline.yaml -p espurna
+Download fly for concourse and login with credentials (where target is your more convenient target name and concourse-url the url of your concourse instance, see [the docs](https://concourse-ci.org/fly.html) for more information)
+- fly -t [target] login -c [concourse-url]
+- fly -t [target] set-pipeline -c pipeline.yaml -p espurna
 
 ## Start deployment
 Go to your concourse and start the first deployment with (+).


### PR DESCRIPTION
The -t flag just provides a convenient name of the target when using fly, concourse-server is a bit misleading here. When using fly the first time, it may be a good idea to provide the concourse url with the -c flag. Added this, too.