### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vars.yaml


### PR DESCRIPTION
vars.yaml potentially contains private data and should therefore be part of .gitignore, so it's more difficult to accidentally commit it.